### PR TITLE
v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.2.x
+
+- Flow can now use `Flow\JobInterface` as job input
+- Add Symfony Bridge
+    - new `Flow\Attribute\AsJob` attribute allows cast job on function or class and embed it's name and description
+
 ## v1.2.1
 
 - Add new Interface Flow\AsyncHandlerInterface to control the Event::SYNC step when processing an IP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.2.x
+## v1.2.2
 
 - Flow can now use `Flow\JobInterface` as job input
 - Add Symfony Bridge

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "keywords": [
     "flow"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "browserslist": [
     "defaults"
   ],

--- a/docs/src/content/en/docs/getting-started/job.md
+++ b/docs/src/content/en/docs/getting-started/job.md
@@ -15,6 +15,16 @@ toc: true
 
 # Job
 
+When using Flow, you can pass Closure or JobInterface, it's useful when you want to specialize your Job, that come with dependecy injection.
+
+## ClosureJob
+
+ClosureJob simplifies job handling by allowing the use of closures or custom job classes, providing a versatile solution for managing jobs in your application.
+
+## YJob
+
+The YJob class defines the Y combinator to recursively apply the job function, making it particularly useful in scenarios where you need to perform recursive tasks without explicitly writing recursive functions.
+
 ## Make your own Job
 
 You can make your custom Job by implementing `Flow\JobInterface`.

--- a/docs/src/content/en/docs/getting-started/job.md
+++ b/docs/src/content/en/docs/getting-started/job.md
@@ -1,0 +1,20 @@
+---
+title: "Job"
+description: "Job."
+lead: "Job."
+date: 2020-10-13T15:21:01+02:00
+lastmod: 2020-10-13T15:21:01+02:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "getting-started"
+weight: 10
+toc: true
+---
+
+# Job
+
+## Make your own Job
+
+You can make your custom Job by implementing `Flow\JobInterface`.

--- a/docs/src/content/en/docs/getting-started/ressources.md
+++ b/docs/src/content/en/docs/getting-started/ressources.md
@@ -93,6 +93,7 @@ Video of Y-Combinator : [https://www.youtube.com/watch?v=QSS_ZcO8Q1g](https://ww
 - Combinator : [https://github.com/loophp/combinator](https://github.com/loophp/combinator)
 - Lambda-php : [https://github.com/igorw/lambda-php](https://github.com/igorw/lambda-php)
 - Deriving the y combinator in 7 easy steps : [https://gist.github.com/igstan/388351](https://gist.github.com/igstan/388351)
+- Y combinator real life application: recursive memoization in clojure : [https://blog.klipse.tech/lambda/2016/08/10/y-combinator-app.html](https://blog.klipse.tech/lambda/2016/08/10/y-combinator-app.html)
 
 ## Messaging approach with East oriented code from [Frédéric Hardy](https://twitter.com/mageekguy)
 

--- a/examples/flow.php
+++ b/examples/flow.php
@@ -17,6 +17,7 @@ use Flow\ExceptionInterface;
 use Flow\Flow\Flow;
 use Flow\Ip;
 use Flow\IpStrategy\MaxIpStrategy;
+use Flow\Job\ClosureJob;
 
 $driver = match (random_int(1, 4)) {
     1 => new AmpDriver(),
@@ -49,7 +50,7 @@ $job1 = static function (DataA $dataA) use ($driver): DataB {
     return new DataB($dataA->id, $d, $dataA->c);
 };
 
-$job2 = static function (DataB $dataB) use ($driver): DataC {
+$job2 = new ClosureJob(static function (DataB $dataB) use ($driver): DataC {
     printf(".* #%d - Job 2 Calculating %d * %d\n", $dataB->id, $dataB->d, $dataB->e);
 
     // simulating calculating some "heavy" operation from from 1 to 3 seconds
@@ -65,7 +66,7 @@ $job2 = static function (DataB $dataB) use ($driver): DataC {
     printf(".* #%d - Job 2 Result for %d * %d = %d and took %.01f seconds\n", $dataB->id, $dataB->d, $dataB->e, $f, $delay);
 
     return new DataC($dataB->id, $f);
-};
+});
 
 $job3 = static function (DataC $dataC): DataD {
     printf("** #%d - Job 3 Result is %d\n", $dataC->id, $dataC->f);

--- a/src/Attribute/AsJob.php
+++ b/src/Attribute/AsJob.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD)]
+class AsJob
+{
+    public function __construct(
+        public string $name = '',
+        public string $description = '',
+    ) {}
+}

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        return new TreeBuilder('flow');
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/FlowExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/FlowExtension.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class FlowExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void {}
+}

--- a/src/Bridge/Symfony/FlowBundle.php
+++ b/src/Bridge/Symfony/FlowBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FlowBundle extends Bundle {}

--- a/src/Bridge/Symfony/Resources/config/services.php
+++ b/src/Bridge/Symfony/Resources/config/services.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {};

--- a/src/Driver/AmpDriver.php
+++ b/src/Driver/AmpDriver.php
@@ -15,6 +15,7 @@ use Flow\Event\PullEvent;
 use Flow\Event\PushEvent;
 use Flow\Exception\RuntimeException;
 use Flow\Ip;
+use Flow\JobInterface;
 use Revolt\EventLoop;
 use Revolt\EventLoop\Driver;
 use RuntimeException as NativeRuntimeException;
@@ -49,10 +50,10 @@ class AmpDriver implements DriverInterface
     /**
      * @return Closure(TArgs): Future<TReturn>
      */
-    public function async(Closure $callback): Closure
+    public function async(Closure|JobInterface $callback): Closure
     {
         return static function (...$args) use ($callback) {
-            return async(static function (Closure $callback, array $args) {
+            return async(static function (Closure|JobInterface $callback, array $args) {
                 try {
                     return $callback(...$args, ...($args = []));
                 } catch (Throwable $exception) {
@@ -86,7 +87,7 @@ class AmpDriver implements DriverInterface
 
     public function await(array &$stream): void
     {
-        $async = function (Closure $job) {
+        $async = function (Closure|JobInterface $job) {
             return function (mixed $data) use ($job) {
                 $async = $this->async($job);
 
@@ -99,7 +100,7 @@ class AmpDriver implements DriverInterface
             };
         };
 
-        $defer = function (Closure $job) {
+        $defer = function (Closure|JobInterface $job) {
             return function (Closure $map) use ($job) {
                 /** @var Closure(TReturn): mixed $map */
                 $future = $this->defer($job);

--- a/src/Driver/ReactDriver.php
+++ b/src/Driver/ReactDriver.php
@@ -13,6 +13,7 @@ use Flow\Event\PullEvent;
 use Flow\Event\PushEvent;
 use Flow\Exception\RuntimeException;
 use Flow\Ip;
+use Flow\JobInterface;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
@@ -46,7 +47,7 @@ class ReactDriver implements DriverInterface
         $this->eventLoop = $eventLoop ?? Loop::get();
     }
 
-    public function async(Closure $callback): Closure
+    public function async(Closure|JobInterface $callback): Closure
     {
         return static function (...$args) use ($callback) {
             return async(static function () use ($callback, $args) {
@@ -81,7 +82,7 @@ class ReactDriver implements DriverInterface
 
     public function await(array &$stream): void
     {
-        $async = function (Closure $job) {
+        $async = function (Closure|JobInterface $job) {
             return function (mixed $data) use ($job) {
                 $async = $this->async($job);
 
@@ -93,7 +94,7 @@ class ReactDriver implements DriverInterface
             };
         };
 
-        $defer = function (Closure $job) {
+        $defer = function (Closure|JobInterface $job) {
             return function ($then) use ($job) {
                 $promise = $this->defer($job);
                 $promise->then($then);

--- a/src/Driver/SpatieDriver.php
+++ b/src/Driver/SpatieDriver.php
@@ -15,6 +15,7 @@ use Flow\Event\PullEvent;
 use Flow\Event\PushEvent;
 use Flow\Exception\RuntimeException;
 use Flow\Ip;
+use Flow\JobInterface;
 use RuntimeException as NativeRuntimeException;
 use Spatie\Async\Pool;
 use Throwable;
@@ -45,7 +46,7 @@ class SpatieDriver implements DriverInterface
         }
     }
 
-    public function async(Closure $callback): Closure
+    public function async(Closure|JobInterface $callback): Closure
     {
         return function (...$args) use ($callback) {
             return function ($onResolve) use ($callback, $args) {
@@ -67,7 +68,7 @@ class SpatieDriver implements DriverInterface
 
     public function await(array &$stream): void
     {
-        $async = function (Closure $job) {
+        $async = function (Closure|JobInterface $job) {
             return function (mixed $data) use ($job) {
                 $async = $this->async($job);
 
@@ -75,7 +76,7 @@ class SpatieDriver implements DriverInterface
             };
         };
 
-        $defer = function (Closure $job) {
+        $defer = function (Closure|JobInterface $job) {
             return function (Closure $onResolve) use ($job) {
                 $this->pool->add(static function () use ($job, $onResolve) {
                     return $job($onResolve, static function ($fn, $next) {

--- a/src/Driver/SwooleDriver.php
+++ b/src/Driver/SwooleDriver.php
@@ -14,6 +14,7 @@ use Flow\Event\PullEvent;
 use Flow\Event\PushEvent;
 use Flow\Exception\RuntimeException;
 use Flow\Ip;
+use Flow\JobInterface;
 use OpenSwoole\Timer;
 use RuntimeException as NativeRuntimeException;
 use Throwable;
@@ -38,7 +39,7 @@ class SwooleDriver implements DriverInterface
         }
     }
 
-    public function async(Closure $callback): Closure
+    public function async(Closure|JobInterface $callback): Closure
     {
         return static function (...$args) use ($callback) {
             return static function ($onResolve) use ($callback, $args) {
@@ -61,7 +62,7 @@ class SwooleDriver implements DriverInterface
 
     public function await(array &$stream): void
     {
-        $async = function (Closure $job) {
+        $async = function (Closure|JobInterface $job) {
             return function (mixed $data) use ($job) {
                 $async = $this->async($job);
 
@@ -69,7 +70,7 @@ class SwooleDriver implements DriverInterface
             };
         };
 
-        $defer = static function (Closure $job) {
+        $defer = static function (Closure|JobInterface $job) {
             return static function (Closure $onResolve) use ($job) {
                 go(static function () use ($job, $onResolve) {
                     try {

--- a/src/DriverInterface.php
+++ b/src/DriverInterface.php
@@ -13,11 +13,11 @@ use Closure;
 interface DriverInterface
 {
     /**
-     * #return Closure(TArgs): void when called this start async $callback.
+     * #return JobInterface<TArgs,void>|Closure(TArgs): void when called this start async $callback.
      *
-     * @param Closure(TArgs): TReturn $callback
+     * @param Closure(TArgs): TReturn|JobInterface<TArgs,TReturn> $callback
      */
-    public function async(Closure $callback): Closure;
+    public function async(Closure|JobInterface $callback): Closure;
 
     /**
      * This allow more granular control on async

--- a/src/Event/AsyncEvent.php
+++ b/src/Event/AsyncEvent.php
@@ -6,20 +6,22 @@ namespace Flow\Event;
 
 use Closure;
 use Flow\Ip;
+use Flow\JobInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * @template T
+ * @template T1
  */
 final class AsyncEvent extends Event
 {
     /**
-     * @param Ip<T> $ip
+     * @param Closure|JobInterface<mixed,mixed> $job
+     * @param Ip<T1>                            $ip
      */
     public function __construct(
         private Closure $async,
         private Closure $defer,
-        private Closure $job,
+        private Closure|JobInterface $job,
         private Ip $ip,
         private Closure $callback
     ) {}
@@ -34,13 +36,16 @@ final class AsyncEvent extends Event
         return $this->defer;
     }
 
-    public function getJob(): Closure
+    /**
+     * @return Closure|JobInterface<mixed,mixed>
+     */
+    public function getJob(): Closure|JobInterface
     {
         return $this->job;
     }
 
     /**
-     * @return Ip<T>
+     * @return Ip<T1>
      */
     public function getIp(): Ip
     {

--- a/src/Flow/FlowDecorator.php
+++ b/src/Flow/FlowDecorator.php
@@ -7,6 +7,7 @@ namespace Flow\Flow;
 use Closure;
 use Flow\FlowInterface;
 use Flow\Ip;
+use Flow\JobInterface;
 
 /**
  * @template T1
@@ -26,7 +27,7 @@ abstract class FlowDecorator implements FlowInterface
         ($this->flow)($ip);
     }
 
-    public function fn(array|Closure|FlowInterface $flow): FlowInterface
+    public function fn(array|Closure|FlowInterface|JobInterface $flow): FlowInterface
     {
         return $this->flow->fn($flow);
     }

--- a/src/Flow/YFlow.php
+++ b/src/Flow/YFlow.php
@@ -9,6 +9,8 @@ use Flow\AsyncHandlerInterface;
 use Flow\DriverInterface;
 use Flow\ExceptionInterface;
 use Flow\IpStrategyInterface;
+use Flow\Job\YJob;
+use Flow\JobInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -20,22 +22,19 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class YFlow extends Flow
 {
     /**
-     * @param null|Closure(ExceptionInterface): void $errorJob
-     * @param null|IpStrategyInterface<T1>           $ipStrategy
-     * @param null|AsyncHandlerInterface<T1>         $asyncHandler
-     * @param null|DriverInterface<T1,T2>            $driver
+     * @param null|Closure(ExceptionInterface): void|JobInterface<ExceptionInterface,void> $errorJob
+     * @param null|IpStrategyInterface<T1>                                                 $ipStrategy
+     * @param null|AsyncHandlerInterface<T1>                                               $asyncHandler
+     * @param null|DriverInterface<T1,T2>                                                  $driver
      */
     public function __construct(
-        Closure $job,
-        ?Closure $errorJob = null,
+        Closure|JobInterface $job,
+        null|Closure|JobInterface $errorJob = null,
         ?IpStrategyInterface $ipStrategy = null,
         ?EventDispatcherInterface $dispatcher = null,
         ?AsyncHandlerInterface $asyncHandler = null,
         ?DriverInterface $driver = null
     ) {
-        $U = static fn (Closure $f) => $f($f);
-        $Y = static fn (Closure $f) => $U(static fn (Closure $x) => $f(static fn ($y) => $U($x)($y)));
-
-        parent::__construct($Y($job), $errorJob, $ipStrategy, $dispatcher, $asyncHandler, $driver);
+        parent::__construct(new YJob($job), $errorJob, $ipStrategy, $dispatcher, $asyncHandler, $driver);
     }
 }

--- a/src/FlowInterface.php
+++ b/src/FlowInterface.php
@@ -20,22 +20,22 @@ interface FlowInterface
     /**
      * @template T2
      *
-     * @param array<mixed>|Closure|FlowInterface<T2> $flow can be Closure as Job, array constructor arguments for Flow instanciation, array configuration for Flow instanciation or FlowInterface instance
-     *                                                     #param ?array{
-     *                                                     0: Closure,
-     *                                                     1?: Closure,
-     *                                                     2?: IpStrategyInterface,
-     *                                                     3?: DriverInterface
-     *                                                     }|array{
-     *                                                     "job"?: Closure,
-     *                                                     "errorJob"?: Closure,
-     *                                                     "ipStrategy"?: IpStrategyInterface,
-     *                                                     "driver"?: DriverInterface
-     *                                                     }|Closure|FlowInterface<T2> $config
+     * @param array<mixed>|Closure(T1): T2|FlowInterface<T2>|JobInterface<T1,T2> $flow can be Closure as Job, array constructor arguments for Flow instanciation, array configuration for Flow instanciation or FlowInterface instance
+     *                                                                                 #param ?array{
+     *                                                                                 0: Closure,
+     *                                                                                 1?: Closure,
+     *                                                                                 2?: IpStrategyInterface,
+     *                                                                                 3?: DriverInterface
+     *                                                                                 }|array{
+     *                                                                                 "job"?: JobInterface|Closure,
+     *                                                                                 "errorJob"?: JobInterface|Closure,
+     *                                                                                 "ipStrategy"?: IpStrategyInterface,
+     *                                                                                 "driver"?: DriverInterface
+     *                                                                                 }|Closure|FlowInterface<T2> $config
      *
      * @return FlowInterface<T1>
      */
-    public function fn(array|Closure|self $flow): self;
+    public function fn(array|Closure|JobInterface|self $flow): self;
 
     /**
      * Do-notation a.k.a. for-comprehension.
@@ -68,8 +68,8 @@ interface FlowInterface
      *  4?: AsyncHandlerInterface,
      *  5?: DriverInterface
      * }|array{
-     *  "jobs"?: Closure|array,
-     *  "errorJobs"?: Closure|array,
+     *  "jobs"?: JobInterface|Closure|array,
+     *  "errorJobs"?: JobInterface|Closure|array,
      *  "ipStrategy"?: IpStrategyInterface<mixed>,
      *  "dispatcher"?: EventDispatcherInterface,
      *  "asyncHandler"?: AsyncHandlerInterface,

--- a/src/Job/ClosureJob.php
+++ b/src/Job/ClosureJob.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Job;
+
+use Closure;
+use Flow\JobInterface;
+
+/**
+ * @template TArgs
+ * @template TReturn
+ *
+ * @implements JobInterface<TArgs,TReturn>
+ */
+class ClosureJob implements JobInterface
+{
+    /**
+     * @param Closure(TArgs): TReturn|JobInterface<TArgs, TReturn> $job
+     */
+    public function __construct(private Closure|JobInterface $job) {}
+
+    public function __invoke($data): mixed
+    {
+        $job = $this->job;
+
+        return $job($data);
+    }
+}

--- a/src/Job/YJob.php
+++ b/src/Job/YJob.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Job;
+
+use Closure;
+use Flow\JobInterface;
+
+/**
+ * @template TArgs
+ * @template TReturn
+ *
+ * @implements JobInterface<TArgs,TReturn>
+ */
+class YJob implements JobInterface
+{
+    /**
+     * @param Closure(mixed): mixed|JobInterface<mixed, mixed> $job
+     */
+    public function __construct(private Closure|JobInterface $job) {}
+
+    public function __invoke($data): mixed
+    {
+        $U = static fn (Closure $f) => $f($f);
+        $Y = static fn (Closure|JobInterface $f) => $U(static fn (Closure $x) => $f(static fn ($y) => $U($x)($y)));
+        $job = $this->job;
+
+        return $Y($job)($data);
+    }
+}

--- a/src/JobInterface.php
+++ b/src/JobInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow;
+
+/**
+ * @template T1
+ * @template T2
+ */
+interface JobInterface
+{
+    /**
+     * @param T1 $data
+     *
+     * @return T2
+     */
+    public function __invoke($data): mixed;
+}

--- a/tests/AsyncHandler/DeferAsyncHandlerTest.php
+++ b/tests/AsyncHandler/DeferAsyncHandlerTest.php
@@ -20,7 +20,7 @@ class DeferAsyncHandlerTest extends TestCase
         $event = new AsyncEvent(
             static fn ($x) => $x,
             static fn ($x) => $x,
-            static function ($args) use (&$result) {
+            static function (array $args) use (&$result) {
                 [[$n1, $n2], $defer] = $args;
                 $result = $n1 + $n2;
 

--- a/tests/Flow/FlowTest.php
+++ b/tests/Flow/FlowTest.php
@@ -16,6 +16,7 @@ use Flow\ExceptionInterface;
 use Flow\Flow\Flow;
 use Flow\Ip;
 use Flow\IpStrategy\MaxIpStrategy;
+use Flow\Job\ClosureJob;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -148,11 +149,17 @@ class FlowTest extends TestCase
         return self::matrix(static function (DriverInterface $driver, $strategyBuilder) use ($exception) {
             $cases = [];
 
-            $cases['job'] = [[[static function (ArrayObject $data) {
+            $cases['closureJob'] = [[[static function (ArrayObject $data) {
                 $data['number'] = 5;
 
                 return $data;
             }, $strategyBuilder(), new AsyncHandler()]], 5];
+
+            $cases['classJob'] = [[[new ClosureJob(static function (ArrayObject $data) {
+                $data['number'] = 6;
+
+                return $data;
+            }), $strategyBuilder(), new AsyncHandler()]], 6];
 
             $strategy = $strategyBuilder();
             if (!$driver instanceof FiberDriver && !$strategy instanceof MaxIpStrategy) {

--- a/tests/Job/ClosureJobTest.php
+++ b/tests/Job/ClosureJobTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Test\Job;
+
+use Flow\Job\ClosureJob;
+use PHPUnit\Framework\TestCase;
+
+class ClosureJobTest extends TestCase
+{
+    public function testJob(): void
+    {
+        $job = new ClosureJob(static function ($n) {
+            return $n + 1;
+        });
+        self::assertSame(3, $job(2));
+    }
+}

--- a/tests/Job/YJobTest.php
+++ b/tests/Job/YJobTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Test\Job;
+
+use Closure;
+use Flow\Job\YJob;
+use PHPUnit\Framework\TestCase;
+
+class YJobTest extends TestCase
+{
+    public function testJob(): void
+    {
+        $job = new YJob(static function (Closure $factorial) {
+            return static function (int $n) use ($factorial) {
+                return $n <= 1 ? 1 : $n * $factorial($n - 1);
+            };
+        });
+
+        self::assertSame(24, $job(4));
+    }
+}


### PR DESCRIPTION
- Flow can now use `Flow\JobInterface` as job input
- Add Symfony Bridge
    - new `Flow\Attribute\AsJob` attribute allows cast job on function or class and embed it's name and description